### PR TITLE
Add public print function to Fixfloat_t

### DIFF
--- a/Quadcoptercpp/Math/custom_math.h
+++ b/Quadcoptercpp/Math/custom_math.h
@@ -1,3 +1,6 @@
+#include<cmath>
+#include<stdio.h>
+
 //Float type between 0 and 1 with guards against over- and underflow.
 class Fixfloat_t{
 private:
@@ -20,6 +23,10 @@ public:
 	Fixfloat_t operator+=(Fixfloat_t rhs);
 	Fixfloat_t operator-=(Fixfloat_t rhs);
 	Fixfloat_t operator*=(Fixfloat_t rhs);
+
+        
+        //Debug
+        void print() { printf("%f\n",(float)this->decimals/pow(2,this->exponent));}
 };
 
 class Quaternion{


### PR DESCRIPTION
Print function for class `Fixfloat_t`
=========
A `print()` member function for debugging is proposed to the class `Fixfloat_t`. The `print` function prints the `Fixfloat_t` in human readable form by doing these steps:
* cast decimal part of `Fixfloat_t` to float
* divide by 2^(exponent part of `Fixfloat_t`)
* print the resulting float using `printf`